### PR TITLE
feat: implement batching for route queries with a minimal store

### DIFF
--- a/dist/index.d.mts
+++ b/dist/index.d.mts
@@ -1,3 +1,16 @@
+/**
+ * Hook to read/write query params in the URL with automatic debounced push.
+ * @param key The query key to read/write
+ * @param defaultValue Default value if key isn't present in the URL
+ *
+ * @example
+ *   const [searchQuery, setSearchQuery] = useRouteQuery("q", "");
+ *   const [page, setPage] = useRouteQuery("page", 1);
+ *   const handleSearch = useCallback((query: string) => {
+ *     setSearchQuery(query);
+ *     setPage(1);
+ *   }, [setSearchQuery, setPage]);
+ */
 declare function useRouteQuery<T extends string | number>(key: string, defaultValue?: T): T extends number ? [number, (newValue: number) => void] : [string, (newValue: string) => void];
 
 export { useRouteQuery };

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,16 @@
+/**
+ * Hook to read/write query params in the URL with automatic debounced push.
+ * @param key The query key to read/write
+ * @param defaultValue Default value if key isn't present in the URL
+ *
+ * @example
+ *   const [searchQuery, setSearchQuery] = useRouteQuery("q", "");
+ *   const [page, setPage] = useRouteQuery("page", 1);
+ *   const handleSearch = useCallback((query: string) => {
+ *     setSearchQuery(query);
+ *     setPage(1);
+ *   }, [setSearchQuery, setPage]);
+ */
 declare function useRouteQuery<T extends string | number>(key: string, defaultValue?: T): T extends number ? [number, (newValue: number) => void] : [string, (newValue: string) => void];
 
 export { useRouteQuery };

--- a/dist/index.js
+++ b/dist/index.js
@@ -27,31 +27,56 @@ module.exports = __toCommonJS(index_exports);
 // src/route/use-route-query.ts
 var import_react = require("react");
 var import_navigation = require("next/navigation");
+function createStore(initialState) {
+  let state = initialState;
+  return {
+    getState: () => state,
+    setState: (updater) => {
+      state = updater(state);
+    }
+  };
+}
+var routeQueryStore = createStore({
+  queryParams: {}
+});
+var globalTimeoutId = null;
+function schedulePush(router, pathname) {
+  if (globalTimeoutId) {
+    clearTimeout(globalTimeoutId);
+  }
+  globalTimeoutId = setTimeout(() => {
+    globalTimeoutId = null;
+    const params = new URLSearchParams(
+      // We cast to `any` to ignore TS complaining about string|number
+      routeQueryStore.getState().queryParams
+    );
+    router.push(`${pathname}?${params.toString()}`);
+  }, 10);
+}
 function useRouteQuery(key, defaultValue) {
   const searchParams = (0, import_navigation.useSearchParams)();
   const router = (0, import_navigation.useRouter)();
   const pathname = (0, import_navigation.usePathname)();
-  const urlValue = searchParams.get(key);
   const setValue = (0, import_react.useCallback)(
     (newValue) => {
-      const params = new URLSearchParams(searchParams.toString());
-      const stringValue = newValue.toString();
-      if (stringValue) {
-        params.set(key, stringValue);
-      } else {
-        params.delete(key);
-      }
-      router.push(`${pathname}?${params.toString()}`);
+      routeQueryStore.setState((prev) => ({
+        ...prev,
+        queryParams: {
+          ...prev.queryParams,
+          [key]: newValue
+        }
+      }));
+      schedulePush(router, pathname);
     },
-    [key, pathname, router, searchParams]
+    [key, router, pathname]
   );
-  let currentValue;
+  const urlValue = searchParams.get(key);
   if (typeof defaultValue === "number") {
     const numericValue = urlValue ? Number(urlValue) : defaultValue;
-    currentValue = isNaN(numericValue) ? defaultValue : numericValue;
+    const currentValue = isNaN(numericValue) ? defaultValue : numericValue;
     return [currentValue, setValue];
   } else {
-    currentValue = urlValue ?? defaultValue ?? "";
+    const currentValue = urlValue ?? defaultValue ?? "";
     return [currentValue, setValue];
   }
 }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1,31 +1,56 @@
 // src/route/use-route-query.ts
 import { useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
+function createStore(initialState) {
+  let state = initialState;
+  return {
+    getState: () => state,
+    setState: (updater) => {
+      state = updater(state);
+    }
+  };
+}
+var routeQueryStore = createStore({
+  queryParams: {}
+});
+var globalTimeoutId = null;
+function schedulePush(router, pathname) {
+  if (globalTimeoutId) {
+    clearTimeout(globalTimeoutId);
+  }
+  globalTimeoutId = setTimeout(() => {
+    globalTimeoutId = null;
+    const params = new URLSearchParams(
+      // We cast to `any` to ignore TS complaining about string|number
+      routeQueryStore.getState().queryParams
+    );
+    router.push(`${pathname}?${params.toString()}`);
+  }, 10);
+}
 function useRouteQuery(key, defaultValue) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
-  const urlValue = searchParams.get(key);
   const setValue = useCallback(
     (newValue) => {
-      const params = new URLSearchParams(searchParams.toString());
-      const stringValue = newValue.toString();
-      if (stringValue) {
-        params.set(key, stringValue);
-      } else {
-        params.delete(key);
-      }
-      router.push(`${pathname}?${params.toString()}`);
+      routeQueryStore.setState((prev) => ({
+        ...prev,
+        queryParams: {
+          ...prev.queryParams,
+          [key]: newValue
+        }
+      }));
+      schedulePush(router, pathname);
     },
-    [key, pathname, router, searchParams]
+    [key, router, pathname]
   );
-  let currentValue;
+  const urlValue = searchParams.get(key);
   if (typeof defaultValue === "number") {
     const numericValue = urlValue ? Number(urlValue) : defaultValue;
-    currentValue = isNaN(numericValue) ? defaultValue : numericValue;
+    const currentValue = isNaN(numericValue) ? defaultValue : numericValue;
     return [currentValue, setValue];
   } else {
-    currentValue = urlValue ?? defaultValue ?? "";
+    const currentValue = urlValue ?? defaultValue ?? "";
     return [currentValue, setValue];
   }
 }

--- a/src/route/use-route-query.ts
+++ b/src/route/use-route-query.ts
@@ -3,43 +3,93 @@
 import { useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 
-function useRouteQuery<T extends string | number>(
+/** Minimal store just to hold query parameters in memory */
+function createStore<T>(initialState: T) {
+  let state = initialState;
+  return {
+    getState: () => state,
+    setState: (updater: (prev: T) => T) => {
+      state = updater(state);
+    },
+  };
+}
+
+const routeQueryStore = createStore<{
+  queryParams: Record<string, string | number>;
+}>({
+  queryParams: {},
+});
+
+/** A single global ref for the scheduled timeout */
+let globalTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Schedules a single router.push after a short delay (10ms)
+ * to batch multiple "setValue" calls that happen at once.
+ */
+function schedulePush(router: ReturnType<typeof useRouter>, pathname: string) {
+  if (globalTimeoutId) {
+    clearTimeout(globalTimeoutId);
+  }
+  globalTimeoutId = setTimeout(() => {
+    globalTimeoutId = null;
+
+    const params = new URLSearchParams(
+      // We cast to `any` to ignore TS complaining about string|number
+      routeQueryStore.getState().queryParams as any
+    );
+    router.push(`${pathname}?${params.toString()}`);
+  }, 10);
+}
+
+/**
+ * Hook to read/write query params in the URL with automatic debounced push.
+ * @param key The query key to read/write
+ * @param defaultValue Default value if key isn't present in the URL
+ *
+ * @example
+ *   const [searchQuery, setSearchQuery] = useRouteQuery("q", "");
+ *   const [page, setPage] = useRouteQuery("page", 1);
+ *   const handleSearch = useCallback((query: string) => {
+ *     setSearchQuery(query);
+ *     setPage(1);
+ *   }, [setSearchQuery, setPage]);
+ */
+export function useRouteQuery<T extends string | number>(
   key: string,
   defaultValue?: T
-): T extends number ? [number, (newValue: number) => void] : [string, (newValue: string) => void] {
+): T extends number
+  ? [number, (newValue: number) => void]
+  : [string, (newValue: string) => void] {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
 
-  const urlValue = searchParams.get(key);
-
-  // Create setValue unconditionally
   const setValue = useCallback(
     (newValue: string | number) => {
-      const params = new URLSearchParams(searchParams.toString());
-      const stringValue = newValue.toString();
-
-      if (stringValue) {
-        params.set(key, stringValue);
-      } else {
-        params.delete(key);
-      }
-
-      router.push(`${pathname}?${params.toString()}`);
+      // Update the store
+      routeQueryStore.setState((prev) => ({
+        ...prev,
+        queryParams: {
+          ...prev.queryParams,
+          [key]: newValue,
+        },
+      }));
+      // Schedule a single route push
+      schedulePush(router, pathname);
     },
-    [key, pathname, router, searchParams]
+    [key, router, pathname]
   );
 
-  // Determine current value
-  let currentValue: string | number;
+  // Get current value from URL
+  const urlValue = searchParams.get(key);
+
   if (typeof defaultValue === "number") {
     const numericValue = urlValue ? Number(urlValue) : defaultValue;
-    currentValue = isNaN(numericValue) ? defaultValue : numericValue;
-    return [currentValue, setValue as (newValue: number) => void] as any;
+    const currentValue = isNaN(numericValue) ? defaultValue : numericValue;
+    return [currentValue, setValue as (val: number) => void] as any;
   } else {
-    currentValue = urlValue ?? defaultValue ?? "";
-    return [currentValue, setValue as (newValue: string) => void] as any;
+    const currentValue = urlValue ?? defaultValue ?? "";
+    return [currentValue, setValue as (val: string) => void] as any;
   }
 }
-
-export { useRouteQuery };


### PR DESCRIPTION

- Introduce a minimal in-memory store (`routeQueryStore`) to manage query parameters.
- Batch multiple `setValue` calls into a single `router.push`, scheduled with a global ref.
- Update `useRouteQuery` to rely on the store and the scheduled push mechanism for debouncing.
- Maintain type safety for string/number query parameters as in the previous version.
